### PR TITLE
added db option

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ Full usage information can be found by running `strprofiler --help`.
 │ --mix_threshold    -mix     INTEGER      Number of markers with >= 2 alleles allowed before a sample is flagged for potential mixing. [default: 3]    │
 │ --sample_map       -sm      PATH         Path to sample map in csv format for renaming. First column should be sample names as given                  |
 |                                            in STR file(s),  second should be new names to assign. No header.                                          │
+│ --database         -db      PATH         Path to an STR database file in csv, xlsx, tsv, or txt format.                                               │
 │ --amel_col         -acol    TEXT         Name of Amelogenin column in STR file(s). [default: AMEL]                                                    │
 │ --sample_col       -scol    TEXT         Name of sample column in STR file(s). [default: Sample]                                                      │
 │ --marker_col       -mcol    TEXT         Name of marker column in STR file(s). Only used if format is 'wide'. [default: Marker]                       │
@@ -145,6 +146,14 @@ In addition to the marker columns, this output contains the following columns:
 | **tanabe_score**        | Tanabe similarity score.                                     |
 | **masters_query_score** | Masters (vs query) similarity score.                         |
 | **masters_ref_score**   | Masters (vs reference) similarity score.                     |
+
+## Database Comparison
+
+**strprofiler** can be also used to compare batches of samples against a larger database of samples. 
+
+`strprofiler -db ExampleSTR_database.csv -o ./strprofiler_output STR1.xlsx`
+
+In this mode, inputs are compared against the database samples only, and not among themselves. Outputs will be as described above for sample input(s). 
 
 ## Contributing
 You can contribute by creating [issues](https://github.com/j-andrews7/strprofiler/issues) to highlight bugs and make suggestions for additional features. [Pull requests](https://github.com/j-andrews7/strprofiler/pulls) are also very welcome.

--- a/tests/ExampleSTR_database.csv
+++ b/tests/ExampleSTR_database.csv
@@ -1,5 +1,5 @@
 Sample Name,marker1,marker2,marker4,Penta D,Penta E,AMEL
-Ref_SampleA,"12, 14",12,"13,13","9,10","12,14",X
+Ref_SampleA,"12, 14",12,"13","9,10","12,14",X
 Ref_SampleB,"12, 14","11.3, 12","13,15","9,10","12,14",X
 Ref_SampleC,"10, 15","11, 12",10,10,"12,14",X
 Ref_SampleD,"9, 16","10, 12","10,14",12,12,X

--- a/tests/ExampleSTR_database.csv
+++ b/tests/ExampleSTR_database.csv
@@ -1,0 +1,6 @@
+Sample Name,marker1,marker2,marker4,Penta D,Penta E,AMEL
+Ref_SampleA,"12, 14",12,"13,13","9,10","12,14",X
+Ref_SampleB,"12, 14","11.3, 12","13,15","9,10","12,14",X
+Ref_SampleC,"10, 15","11, 12",10,10,"12,14",X
+Ref_SampleD,"9, 16","10, 12","10,14",12,12,X
+Ref_SampleE,14,13,"13,15",13,"12,15","X,Y"

--- a/tests/unit/test_database.py
+++ b/tests/unit/test_database.py
@@ -1,0 +1,110 @@
+import strprofiler as sp
+import pytest
+from pathlib import Path
+import pandas as pd
+
+THIS_DIR = Path(__file__).parent
+
+exp_database = Path(THIS_DIR / "../ExampleSTR_database.csv")
+paths = [exp_database]
+
+@pytest.mark.parametrize("paths", [(paths)])
+def test_database_ingress(paths):
+
+    # Check that database ingress row and column names are correct when penta fix applied.
+    df = sp.str_ingress(
+        paths,
+        sample_col="Sample Name",
+        marker_col="Marker",
+        sample_map=None,
+        penta_fix=True,
+    )
+
+    assert list(df.index) == ["Ref_SampleA", "Ref_SampleB", "Ref_SampleC", "Ref_SampleD", "Ref_SampleE"]
+    assert set(df.columns) == set(
+        ["marker1", "marker2", "marker4", "PentaD", "PentaE", "AMEL"]
+    )
+
+    # Check that dataframe row and column names are correct when  penta fix not applied.
+    df = sp.str_ingress(
+        paths,
+        sample_col="Sample Name",
+        marker_col="Marker",
+        sample_map=None,
+        penta_fix=False,
+    )
+
+    assert list(df.index) == ["Ref_SampleA", "Ref_SampleB", "Ref_SampleC", "Ref_SampleD", "Ref_SampleE"]
+    assert set(df.columns) == set(
+        [
+            "marker1",
+            "marker2",
+            "marker4",
+            "Penta D",
+            "Penta E",
+            "AMEL",
+        ]
+    )
+
+    # Check the samples are being parsed properly.
+    assert list(
+        df.loc[
+            "Ref_SampleA",
+        ]
+    ) == ["12,14","12","13","9,10","12,14","X"]
+    
+    # Check the samples are being parsed properly.
+    assert list(
+        df.loc[
+            "Ref_SampleE",
+        ]
+    ) == ["14","13","13,15","13","12,15","X,Y"]
+
+
+
+# Re-test scoring with database reference df.
+query = {
+    "marker1": "12,14", 
+    "marker2": "12", 
+    "marker4": "13", 
+    "Penta D": "9,10",
+    "Penta E": "12,14",
+    "AMEL": "X"
+}
+
+reference = pd.DataFrame({
+    "Sample": ["Ref_SampleA", "Ref_SampleB", "Ref_SampleE"],
+    "marker1": ["12,14", "12,14", "14"],
+    "marker2": ["12", "11.3,12", ""],
+    "marker4": ["13", "13,15", "13,15"],
+    "Penta D": ["9,10", "9,10", "13"],
+    "Penta E": ["12,14", "12,14", ""],
+    "AMEL": ["X", "X", "X,Y"]
+}).set_index('Sample').to_dict(orient="index")
+
+@pytest.mark.parametrize("query, reference, use_amel", [(query, reference, True)])
+def test_database_scoring(query, reference, use_amel):
+
+    # Check scoring for query against Ref_SampleA
+    scores = sp.score_query(query, reference['Ref_SampleA'], use_amel=use_amel, amel_col="AMEL")
+    assert scores["n_shared_markers"] == 6
+    assert scores["n_shared_alleles"] == 9
+    assert scores["n_query_alleles"] == 9
+    assert scores["n_reference_alleles"] == 9
+    tan_score = scores["tanabe_score"]
+    assert f"{tan_score:.2f}" == "100.00"
+    assert scores["masters_query_score"] == 100.0
+    mr_score = scores["masters_ref_score"]
+    assert f"{mr_score:.2f}" == "100.00"
+
+    # Check scoring for query against Ref_SampleE
+    scores = sp.score_query(query, reference['Ref_SampleE'], use_amel=use_amel, amel_col="AMEL")
+    assert scores["n_shared_markers"] == 4
+    assert scores["n_shared_alleles"] == 3
+    assert scores["n_query_alleles"] == 6
+    assert scores["n_reference_alleles"] == 6
+    tan_score = scores["tanabe_score"]
+    assert f"{tan_score:.2f}" == "50.00"
+    assert scores["masters_query_score"] == 50.0
+    mr_score = scores["masters_ref_score"]
+    assert f"{mr_score:.2f}" == "50.00"


### PR DESCRIPTION
Database option added. 

Three straightforward changes to accomplish this: 

1. Added optional `-db` / `--database` click variable. 
2. Existing input ingress function is used to parse the optional DB file. 
3. Existing nested comparison loop inner loop was modified to have the inner loop 'reference' dict set as either all other inputs (existing `samps`) or if database, then the DB dataframe. 

Given the nature of this addition, I am not sure if additional test files are needed., etc., but I am happy to add if needed. 